### PR TITLE
Refactor & bugfix for NREL/GHGRP_for_Energy

### DIFF
--- a/envirofacts_api/Get_GHGRP_data.py
+++ b/envirofacts_api/Get_GHGRP_data.py
@@ -1,22 +1,29 @@
 # -*- coding: utf-8 -*-
 """
-Last updated 8/12/2020 by @calmc, colin.mcmillan@nrel.gov
+Original code by @calmc, colin.mcmillan@nrel.gov (2020-08-12)
+Refactored by @pennelise, epenn@g.harvard.edu (2023-05-08)
 """
 #
 import pandas as pd
+import numpy as np
 import requests
-import xml.etree.ElementTree as et
-import sys
-import re
-import os
+from typing import Optional
 
 
-class GHGRP_API():
+class GHGRP_API:
     """
-    Access GHGRP data through Envirofacts API. Currently written to
-    apply only to tables C_FUEL_LEVEL_INFORMATION,
-    D_FUEL_LEVEL_INFORMATION, c_configuration_level_info, and
-    V_GHG_EMITTER_FACILITIES.
+    Access GHGRP data through Envirofacts API.
+    The query should work for most tables associated with GHGRP, but only the
+    following tables have been tested:
+        - All of section FF (coal)
+        - C_FUEL_LEVEL_INFORMATION
+        - D_FUEL_LEVEL_INFORMATION
+        - c_configuration_level_info
+        - V_GHG_EMITTER_FACILITIES
+    For a full list of available tables see:
+        https://www.epa.gov/enviro/greenhouse-gas-model
+    For detailed documentation on the API see:
+        https://www.epa.gov/enviro/web-services#table
 
     Example
     -------
@@ -24,170 +31,142 @@ class GHGRP_API():
     from table V_GHG_EMITTER_FACILITIES for the 2018 reporting year::
 
         from Get_GHGRP_data import GHGRP_API
-        emitter_facility_info = GHGRP_API().get_data(2018,
-                                                     'V_GHG_EMITTER_FACILITIES')
+        emitter_facility_info = GHGRP_API().get_data(
+            table='V_GHG_EMITTER_FACILITIES', reporting_year=2018)
 
     """
 
+    BASE_URL = "https://enviro.epa.gov/enviro/efservice/"
+
     @staticmethod
-    def xml_to_df(xml_root, table_name, df_columns):
+    def read_path(path: str) -> pd.DataFrame:
+        """Read a CSV file from a URL."""
+        assert requests.get(path).status_code == 200, "URL does not exist."
+        return pd.read_csv(path, low_memory=False)
+
+    def get_table_slice(
+        self,
+        table: str,
+        start_row: int,
+        end_row: int,
+        custom_query: Optional[str] = None,
+    ) -> pd.DataFrame:
         """
-        Converts elements of xml string obtained from EPA Envirofacts
-        to a DataFrame.
+        Query a slice of a table from the EPA API.
 
         Parameters
         ----------
-        xml_root : xml.etree.ElementTree.Element
-            XML content from API call.
-
-        table_name : string
-            Name of GHGRP Envirofacts table.
-
-        df_columns : int
-
-        Returns
-        -------
-        rpd : pandas DataFrame
-            Dataframe of entries from API call.
-        """
-        rpd = pd.DataFrame()
-
-        for c in df_columns:
-            cl = []
-
-            for field in xml_root.findall(table_name):
-                cl.append(field.find(c).text)
-
-            cs = pd.Series(cl, name=c)
-            rpd = pd.concat([rpd, cs], axis=1)
-
-        return rpd
-
-    @classmethod
-    def get_data(cls, reporting_year, table, rows=None):
-        """
-        Return GHGRP data using EPA RESTful API based on specified reporting
-        year and table. Tables of interest are C_FUEL_LEVEL_INFORMATION,
-        D_FUEL_LEVEL_INFORMATION, c_configuration_level_info, and
-        V_GHG_EMITTER_FACILITIES.
-        Optional argument to specify number of table rows.
-
-        Parameters
-        ----------
-        reporting_year : int
-            Year of data to download.
-
-        table : str
-            Name of GHGRP Envirofacts table to acces.
-
-        rows : int, optional
-            Number of rows of data to return. Default value is None, which
-            requests the API for all rows of the table.
+        table: str
+            Name of the GHGRP Envirofacts table to query.
+        start_row: int
+            First row to query.
+        end_row: int
+            Last row to query.
+        custom_query: str, optional
+            Custom query to add to the URL. See
+            https://www.epa.gov/enviro/web-services#table
+            for detailed documentation on the API. Custom queries are steps 2, 3, and 4
+            in the "Constructing a Search" section of the documentation.
 
         Returns
         -------
-        ghgrp_data : pandas DataFrame
-            Dataframe of data requested from the Envirofacts API for the
-            defined year and table.
+        ghgrp_data:
+            Dataframe of the queried table.
         """
+        custom_query = custom_query or ""
+        path = f"{self.BASE_URL}/{table}/{custom_query}/rows/{start_row}:{end_row}/csv"
+        return self.read_path(path)
 
-        # Envirofacts API
-        base_url = 'https://enviro.epa.gov/enviro/efservice/'
-
-        # Different GHGRP Envirofacts tables have different naming
-        # conventions for the year of data.
-        if re.match(r'(V_GHG_EMITTER_)|(W_LIQUIDS_)', table):
-            table_url = os.path.join(base_url+table+'/YEAR/',
-                                     str(reporting_year))
-
+    def get_row_count(self, table: str, custom_query: Optional[str] = None) -> int:
+        custom_query = custom_query or ""
+        path = f"{self.BASE_URL}/{table}/{custom_query}/count/csv"
+        df = self.read_path(path)
+        if "TOTALQUERYRESULTS" in df.columns:
+            count = int(df["TOTALQUERYRESULTS"].values[0])
+        elif df.empty:  # some tables return only the count, with no column name
+            count = int(df.columns.values[0])
         else:
-            table_url = os.path.join(base_url+table+'/REPORTING_YEAR/',
-                                     str(reporting_year))
+            raise ValueError("Count file format not recognized.")
+        return count
 
-        r_columns = requests.get(table_url + '/rows/0:1')
-        r_columns_root = et.fromstring(r_columns.content)
+    def get_reporting_year_query(
+        self, table: str, reporting_year: Optional[int] = None
+    ) -> str:
+        if reporting_year is None:
+            return ""
+        else:
+            path = f"{self.BASE_URL}/{table}/rows/0:1/csv"
+            df = self.read_path(path)
+            if "reporting_year" in df.columns.str.lower():
+                reporting_year_query = f"reporting_year/{reporting_year}"
+            elif "year" in df.columns.str.lower():
+                reporting_year_query = f"year/{reporting_year}"
+            else:
+                raise ValueError("Column name for reporting year not recognized.")
+            return reporting_year_query
 
-        # Collect names of columns in a list
-        clist = []
-        for child in r_columns_root[0]:
-            clist.append(child.tag)
+    def get_data(
+        self, table, reporting_year: Optional[int] = None, rows: Optional[int] = None
+    ):
+        """
+        Query a table from the EPA API, 10,000 rows at a time.
 
-        ghgrp_data = pd.DataFrame(columns=clist)
+        Parameters
+        ----------
+        table: str
+            Name of the GHGRP Envirofacts table to access.
+        reporting_year: int, optional
+            Year of data to download. Default value is None, which will download all years of data.
+        rows: int, optional
+            Number of rows to download. Defaults value is None, which will download all rows of the table.
+
+        Returns
+        -------
+        ghgrp_data:
+            Dataframe of the queried table.
+        """
+        reporting_year_query = self.get_reporting_year_query(
+            table=table, reporting_year=reporting_year
+        )
 
         if rows is None:
             # Get number of rows of request, if not specified.
             # If rows is None then all rows of the table will be requested.
-            try:
-                r = requests.get(table_url + '/count/')
+            nrecords = self.get_row_count(
+                table=table, custom_query=reporting_year_query
+            )
+            ghgrp_data = []
 
-            except requests.exceptions.RequestException as e:
-                print(e, table_url)
-                sys.exit(1)
-
+            # EPA API can only handle 10,000 records at a time.
+            if nrecords < 10000:
+                ghgrp_data = self.get_table_slice(
+                    table=table,
+                    start_row=0,
+                    end_row=nrecords,
+                    custom_query=reporting_year_query,
+                )
             else:
-                nrecords = int(et.fromstring(r.content)[0].text)
-
-            # Limit to requesting >10,000 records?
-            # This could be refactored.
-            if nrecords > 10000:
-                rrange = range(0, nrecords, 10000)
-
+                rrange = np.append(
+                    np.arange(start=0, stop=nrecords, step=10000, dtype=int), nrecords
+                )
                 # Call
                 for n in range(len(rrange) - 1):
-                    try:
-                        r_records = requests.get(table_url + '/rows/' +
-                                                 str(rrange[n]) + ':' +
-                                                 str(rrange[n + 1]))
-
-                    except requests.exceptions.RequestException as e:
-                        print(e, table_url)
-                        sys.exit(1)
-
-                    else:
-                        records_root = et.fromstring(r_records.content)
-                        r_df = GHGRP_API.xml_to_df(records_root, table,
-                                                   ghgrp_data.columns)
-                        ghgrp_data = ghgrp_data.append(r_df)
-
-                records_last = requests.get(table_url + '/rows/' +
-                                            str(rrange[-1]) + ':' +
-                                            str(nrecords))
-
-                records_lroot = et.fromstring(records_last.content)
-                rl_df = GHGRP_API.xml_to_df(records_lroot, table,
-                                            ghgrp_data.columns)
-                ghgrp_data = ghgrp_data.append(rl_df)
-
-            else:
-                try:
-                    r_records = \
-                        requests.get(table_url + '/rows/0:' + str(nrecords))
-
-                except requests.exceptions.RequestException as e:
-                    print(e, table_url)
-                    sys.exit(1)
-
-                else:
-                    records_root = et.fromstring(r_records.content)
-                    r_df = GHGRP_API.xml_to_df(records_root, table,
-                                               ghgrp_data.columns)
-                    ghgrp_data = ghgrp_data.append(r_df)
-
+                    r_records = self.get_table_slice(
+                        table=table,
+                        start_row=rrange[n],
+                        end_row=rrange[n + 1],
+                        custom_query=reporting_year_query,
+                    )
+                    ghgrp_data.append(r_records)
+                ghgrp_data = pd.concat(ghgrp_data)
         else:
-            try:
-                r_records = requests.get(table_url + '/rows/0:' + str(rows))
+            ghgrp_data = self.get_table_slice(
+                table=table,
+                start_row=0,
+                end_row=rows,
+                custom_query=reporting_year_query,
+            )
 
-            except requests.exceptions.RequestException as e:
-                print(e, table_url)
-                sys.exit(1)
-
-            else:
-                records_root = et.fromstring(r_records.content)
-                r_df = GHGRP_API.xml_to_df(records_root, table,
-                                           ghgrp_data.columns)
-                ghgrp_data = ghgrp_data.append(r_df)
-
-        # Drop any duplicate row entries.
-        ghgrp_data.drop_duplicates(inplace=True)
+        ghgrp_data.drop_duplicates(inplace=True)  # Drop any duplicate row entries.
 
         return ghgrp_data

--- a/envirofacts_api/Get_GHGRP_data.py
+++ b/envirofacts_api/Get_GHGRP_data.py
@@ -149,7 +149,6 @@ class GHGRP_API:
                 rrange = np.append(
                     np.arange(start=0, stop=nrecords, step=10000, dtype=int), nrecords
                 )
-                # Call
                 for n in range(len(rrange) - 1):
                     r_records = self.get_table_slice(
                         table=table,


### PR DESCRIPTION
Hi! I really like your project. I wanted to use it, but I found that it was broken for most tables (probably due to some update on the API in the last few years). I refactored it to fix these for my own project, feel free pull these changes in if you want. 

## Refactor & bugfix for NREL/GHGRP_for_Energy
1. Fix broken code (most likely introduced by API updates)
2. Enable querying the FF (coal) section. 
3. Take advantage of the Envirofacts CSV option to simplify code (we don't have to walk the XML tree anymore). 

Not backwards compatible: 
- All the tables supported in the last version are still tested & supported. 
- However, the order of the arguments is flipped in this version because `reporting_year` is now an optional argument. The interface is now:
```GHGRP_API().get_data('V_GHG_EMITTER_FACILITIES', 2018)``` 
rather than: 
```GHGRP_API().get_data(2018, 'V_GHG_EMITTER_FACILITIES')```